### PR TITLE
Fixed bug in FDS configuration

### DIFF
--- a/main/include/app_config.h
+++ b/main/include/app_config.h
@@ -50,6 +50,10 @@
 #define FDS_ENABLED 1
 #define FDS_BACKEND NRF_FSTORAGE_SD
 #define NRF_FSTORAGE_ENABLED 1
+// Number of virtual flash pages used for FDS data storage.
+// NOTE: This value must correspond to FDS_FLASH_PAGES specified in
+// linker directives (.ld) file.
+#define FDS_VIRTUAL_PAGES 2
 
 // ----- Logging Config -----
 

--- a/main/ldscripts/openweave-nrf52840-lock-example.ld
+++ b/main/ldscripts/openweave-nrf52840-lock-example.ld
@@ -1,18 +1,40 @@
 SEARCH_DIR(.)
 GROUP(-lgcc -lc -lnosys)
 
+/* Total size of device FLASH in bytes */
 TOTAL_FLASH_SIZE = 0x100000;
+
+/* Total size of device RAM in bytes */
 TOTAL_RAM_SIZE = 0x40000;
+
+/* Size of an individual FLASH page in bytes */
 FLASH_PAGE_SIZE = 4096;
+
+/* Number of FLASH pages reserved for Nordic FDS.  NOTE: This MUST correspond
+ * to the value specified for FDS_VIRTUAL_PAGES in app_config.h */
+FDS_FLASH_PAGES = 2;
+
+/* Number of FLASH pages reserved for OpenThread data storage. */
+OT_DATA_FLASH_PAGES = 4;
 
 MEMORY
 {
+    /* FLASH region occupied by the Nordic SoftDevice */
     SD_FLASH (rx) : ORIGIN = 0, LENGTH = 0x26000
+    
+    /* RAM region used by the Nordic SoftDevice */
     SD_RAM (rw) : ORIGIN = 0x20000000, LENGTH = 0x5800
 
-    OT_DATA_FLASH (rw) : ORIGIN = TOTAL_FLASH_SIZE - (FLASH_PAGE_SIZE * 4), LENGTH = (FLASH_PAGE_SIZE * 4)
+    /* FLASH region used for Nordic FDS value storage. */
+    FDS_FLASH (rw) : ORIGIN = TOTAL_FLASH_SIZE - (FLASH_PAGE_SIZE * FDS_FLASH_PAGES), LENGTH = (FLASH_PAGE_SIZE * FDS_FLASH_PAGES)
+
+    /* FLASH region used for OpenThread data storage. */ 
+    OT_DATA_FLASH (rw) : ORIGIN = ORIGIN(FDS_FLASH) - (FLASH_PAGE_SIZE * OT_DATA_FLASH_PAGES), LENGTH = (FLASH_PAGE_SIZE * OT_DATA_FLASH_PAGES)
     
+    /* FLASH region used for application code and read-only data. */
     FLASH (rx) : ORIGIN = ORIGIN(SD_FLASH) + LENGTH(SD_FLASH), LENGTH = ORIGIN(OT_DATA_FLASH) - ORIGIN(FLASH)
+    
+    /* RAM region used for application dynamic data. */
     RAM (rw) : ORIGIN = ORIGIN(SD_RAM) + LENGTH(SD_RAM), LENGTH = TOTAL_RAM_SIZE - LENGTH(SD_RAM)
 }
 


### PR DESCRIPTION
-- Fixed a linker misconfiguration that resulted in an overlap between the region of FLASH used to store FDS value (e.g. Weave configuration) and the region used to store OpenThread configuration.

IMPORTANT NOTE: This change requires all devices to be erased and re-configured.

-- Reduced the size of FDS FLASH from 3 pages (12KB) to 2 pages (8KB).

-- Updated OpenWeave commit to 6270892.