### PR TITLE
Fix log line message

### DIFF
--- a/main/AppTask.cpp
+++ b/main/AppTask.cpp
@@ -328,7 +328,7 @@ void AppTask::FunctionTimerEventHandler(AppEvent * aEvent)
     // If we reached here, the button was held past FACTORY_RESET_TRIGGER_TIMEOUT, initiate factory reset
     if (sAppTask.mFunctionTimerActive && sAppTask.mFunction == kFunction_SoftwareUpdate)
     {
-        NRF_LOG_INFO("Factory Reset Triggered. Press button again to cancel");
+        NRF_LOG_INFO("Factory Reset Triggered. Release button within %ums to cancel.", FACTORY_RESET_TRIGGER_TIMEOUT);
 
         // Start timer for FACTORY_RESET_CANCEL_WINDOW_TIMEOUT to allow user to cancel, if required.
         sAppTask.StartTimer(FACTORY_RESET_CANCEL_WINDOW_TIMEOUT);


### PR DESCRIPTION
Fix a message that is logged when factory reset is triggered to reflect the correct factory reset cancellation procedure.