### PR TITLE
Replace newlib printf functions and switch to newlib nano

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/openthread"]
 	path = third_party/openthread
 	url = https://github.com/openthread/openthread.git
+[submodule "third_party/printf"]
+	path = third_party/printf
+	url = https://github.com/mpaland/printf.git

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ SRCS = \
     $(PROJECT_ROOT)/main/support/CXXExceptionStubs.cpp \
     $(PROJECT_ROOT)/main/support/nRF5Sbrk.c \
     $(PROJECT_ROOT)/main/support/FreeRTOSNewlibLockSupport.c \
+    $(PROJECT_ROOT)/main/support/AltPrintf.c \
+    $(PROJECT_ROOT)/third_party/printf/printf.c \
     $(NRF5_SDK_ROOT)/components/ble/common/ble_advdata.c \
     $(NRF5_SDK_ROOT)/components/ble/common/ble_srv_common.c \
     $(NRF5_SDK_ROOT)/components/ble/nrf_ble_gatt/nrf_ble_gatt.c \
@@ -114,6 +116,7 @@ INC_DIRS = \
     $(PROJECT_ROOT)/main/include \
     $(PROJECT_ROOT)/main/traits/include \
     $(PROJECT_ROOT)/main/schema/include \
+    $(PROJECT_ROOT)/third_party/printf \
     $(NRF5_SDK_ROOT)/components \
     $(NRF5_SDK_ROOT)/components/boards \
     $(NRF5_SDK_ROOT)/components/ble/ble_advertising \
@@ -168,7 +171,14 @@ DEFINES = \
     USE_APP_CONFIG \
     __HEAP_SIZE=40960 \
     __STACK_SIZE=8192 \
-    SOFTDEVICE_PRESENT
+    SOFTDEVICE_PRESENT \
+    PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+
+CFLAGS = \
+    --specs=nano.specs
+
+LDFLAGS = \
+    --specs=nano.specs
 
 OPENWEAVE_PROJECT_CONFIG = $(PROJECT_ROOT)/main/include/WeaveProjectConfig.h
 

--- a/main/support/AltPrintf.c
+++ b/main/support/AltPrintf.c
@@ -1,0 +1,148 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Substitute newlib printf functions with an alternate, minimal implementation.
+ *
+ *          This code is intended to work with the tiny printf implementation published by
+ *          Marco Paland (https://github.com/mpaland/printf).
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+// Include header file from mpaland printf.
+#include "printf.h"
+
+// Disable the mapping #defines from the printf.h header so the following functions don't get renamed.
+#undef printf
+#undef sprintf
+#undef snprintf
+#undef vsnprintf
+#undef vprintf
+
+int printf(const char* format, ...)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int sprintf(char* buffer, const char* format, ...)
+{
+    /* Dangerous; should not be called */
+    buffer[0] = 0;
+    return -1;
+}
+
+int snprintf(char* buffer, size_t count, const char* format, ...)
+{
+    int res;
+    va_list va;
+    va_start(va, format);
+    res = vsnprintf_(buffer, count, format, va);
+    va_end(va);
+    return res;
+}
+
+int vprintf(const char* format, va_list va)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int vsprintf(char* buffer, const char* format, va_list va)
+{
+    /* Dangerous; should not be called */
+    buffer[0] = 0;
+    return -1;
+}
+
+int vsnprintf(char* buffer, size_t count, const char* format, va_list va)
+{
+    return vsnprintf_(buffer, count, format, va);
+}
+
+int fprintf(FILE *stream, const char *format, ...)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int vfprintf(FILE *stream, const char *format, va_list ap)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+/* iprintf variants */
+
+int iprintf(const char* format, ...)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int siprintf(char* buffer, const char* format, ...)
+{
+    /* Dangerous; should not be called */
+    buffer[0] = 0;
+    return -1;
+}
+
+int sniprintf(char* buffer, size_t count, const char* format, ...)
+{
+    int res;
+    va_list va;
+    va_start(va, format);
+    res = vsnprintf_(buffer, count, format, va);
+    va_end(va);
+    return res;
+}
+
+int viprintf(const char* format, va_list va)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int vsiprintf(char* buffer, const char* format, va_list va)
+{
+    /* Dangerous; should not be called */
+    buffer[0] = 0;
+    return -1;
+}
+
+int vsniprintf(char* buffer, size_t count, const char* format, va_list va)
+{
+    return vsnprintf_(buffer, count, format, va);
+}
+
+int fiprintf(FILE *stream, const char *format, ...)
+{
+    /* Stdio not supported */
+    return -1;
+}
+
+int vfiprintf(FILE *stream, const char *format, va_list ap)
+{
+    /* Stdio not supported */
+    return -1;
+}


### PR DESCRIPTION
-- Reduced RAM and flash utilization by replacing the newlib printf functions with an alternate, open-source implementation.  mpaland printf (https://github.com/mpaland/printf) is a tiny but “fully loaded” printf implementation specifically designed for usage in embedded systems.  It is incorporated as a third_party submodule and has an MIT license. This change reduced flash size by 18K.

-- Link against newlib nano library.  This reduces flash size by an additional 10K.
