### PR TITLE
Configure example app as Thread sleepy end device

### DIFF
--- a/main/include/app_config.h
+++ b/main/include/app_config.h
@@ -130,5 +130,9 @@
 #define SWU_INTERVAl_WINDOW_MIN_MS				(23*60*60*1000) // 23 hours
 #define SWU_INTERVAl_WINDOW_MAX_MS				(24*60*60*1000) // 24 hours
 
+// ---- Thread Polling Config ----
+#define THREAD_ACTIVE_POLLING_INTERVAL_MS       100
+#define THREAD_INACTIVE_POLLING_INTERVAL_MS     1000
+
 
 #endif //APP_CONFIG_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -263,6 +263,28 @@ int main(void)
     //
     mbedtls_platform_set_calloc_free(calloc, free);
 
+    // Configure device to operate as a Thread sleepy end-device.
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_SleepyEndDevice);
+    if (ret != WEAVE_NO_ERROR)
+    {
+        NRF_LOG_INFO("ConnectivityMgr().SetThreadDeviceType() failed");
+        APP_ERROR_HANDLER(ret);
+    }
+
+    // Configure the Thread polling behavior for the device.
+    {
+        ConnectivityManager::ThreadPollingConfig pollingConfig;
+        pollingConfig.Clear();
+        pollingConfig.ActivePollingIntervalMS = THREAD_ACTIVE_POLLING_INTERVAL_MS;
+        pollingConfig.InactivePollingIntervalMS = THREAD_INACTIVE_POLLING_INTERVAL_MS;
+        ret = ConnectivityMgr().SetThreadPollingConfig(pollingConfig);
+        if (ret != WEAVE_NO_ERROR)
+        {
+            NRF_LOG_INFO("ConnectivityMgr().SetThreadPollingConfig() failed");
+            APP_ERROR_HANDLER(ret);
+        }
+    }
+
     NRF_LOG_INFO("Starting Weave task");
 
     ret = PlatformMgr().StartEventLoopTask();


### PR DESCRIPTION
-- Modified the initialization code for the lock example app to configure Thread to operate as a sleepy end device, and to configure the parent polling interval.  Polling interval is set to 100ms when the device is engaged in a Weave exchange with an outside party (e.g. the service) and 1 sec when it is idle.