### PR TITLE
Set default importance level for event logging as Debug

### DIFF
--- a/main/include/WeaveProjectConfig.h
+++ b/main/include/WeaveProjectConfig.h
@@ -137,4 +137,13 @@
  */
 #define WEAVE_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
 
+/**
+ * WEAVE_CONFIG_EVENT_LOGGING_DEFAULT_IMPORTANCE
+ *
+ * Set the default importance of events to be logged as Debug. Since debug is the lowest
+ * importance level, this means all standard, critical, info and debug importance level
+ * vi events get logged.
+ */
+#define WEAVE_CONFIG_EVENT_LOGGING_DEFAULT_IMPORTANCE nl::Weave::Profiles::DataManagement::Debug
+
 #endif // WEAVE_PROJECT_CONFIG_H


### PR DESCRIPTION
-- Since debug is the lowest importance level, this means all standard, critical, info and debug importance level events get logged.
-- Update openweave-core submodule to 1d33feaa6b3e97f2812b2dd34185696f981602ea