### PR TITLE
Enable nRF5 SDK ASSERTs

### DIFF
--- a/main/include/FreeRTOSConfig.h
+++ b/main/include/FreeRTOSConfig.h
@@ -30,6 +30,7 @@
 #ifndef FREERTOS_CONFIG_H
 #define FREERTOS_CONFIG_H
 
+#include "sdk_config.h"
 #ifdef SOFTDEVICE_PRESENT
 #include "nrf_soc.h"
 #endif

--- a/main/include/app_config.h
+++ b/main/include/app_config.h
@@ -101,6 +101,10 @@
 
 // ----- Misc Config -----
 
+// Enable the Nordic ASSERT() macro.  This also has the effect of enabling
+// FreeRTOS configASSERT() due to logic in FreeRTOSConfig.h
+#define DEBUG_NRF 1
+
 #define NRF_CLOCK_ENABLED 1
 #define NRF_FPRINTF_ENABLED 1
 #define NRF_STRERROR_ENABLED 1
@@ -133,6 +137,5 @@
 // ---- Thread Polling Config ----
 #define THREAD_ACTIVE_POLLING_INTERVAL_MS       100
 #define THREAD_INACTIVE_POLLING_INTERVAL_MS     1000
-
 
 #endif //APP_CONFIG_H


### PR DESCRIPTION
-- Enable the ASSERT() macro defined in the Nodic nRF5 SDK by default.  This also This also
has the effect of enabling FreeRTOS’s configASSERT() macro.

-- Ensure that FreeRTOSConfig.h include the Nordic sdk_config.h, so that FreeRTOS
configuration reflects choices made in the application’s app_config.h

-- Update third-party/openweave-core to commit 7691a8e.