### PR TITLE
[toble] Enable ToBLE feature when third_party/openthread supports it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@
 PROJECT_ROOT := $(realpath .)
 
 OPENWEAVE_ROOT ?= $(PROJECT_ROOT)/third_party/openweave-core
+OPENTHREAD_ROOT ?= $(PROJECT_ROOT)/third_party/openthread
 
 BUILD_SUPPORT_DIR = $(OPENWEAVE_ROOT)/build/nrf5
 
@@ -160,7 +161,8 @@ INC_DIRS = \
     $(NRF5_SDK_ROOT)/modules/nrfx \
     $(NRF5_SDK_ROOT)/modules/nrfx/drivers/include \
     $(NRF5_SDK_ROOT)/modules/nrfx/hal \
-    $(NRF5_SDK_ROOT)/modules/nrfx/mdk
+    $(NRF5_SDK_ROOT)/modules/nrfx/mdk \
+    $(OPENTHREAD_ROOT)/examples/platforms/nrf52840
 
 DEFINES = \
     NRF52840_XXAA \

--- a/main/include/OpenThreadConfig.h
+++ b/main/include/OpenThreadConfig.h
@@ -25,6 +25,8 @@
 #ifndef OPENTHREAD_PLATFORM_CONFIG_H
 #define OPENTHREAD_PLATFORM_CONFIG_H
 
+#include "ble_config.h"
+
 // Disable the Nordic-supplied OpenThread logging facilities and use
 // the facilities provided by the OpenWeave Device Layer (see
 // openweave/src/adaptations/device-layer/nRF5/Logging.cpp).
@@ -45,8 +47,34 @@
 // Use smaller maximum interval to speed up reattaching.
 #define OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL (60 * 10 * 1000) // default 1200000 ms
 
+// ==============================================================
+//          CONFIG TOBLE
+// ==============================================================
+
+#if OPENTHREAD_CONFIG_ENABLE_TOBLE
+
+#define OPENTHREAD_CONFIG_ENABLE_BLE 1
+#define OPENTHREAD_CONFIG_ENABLE_TOBLE_TO_BLE 1
+#define OPENTHREAD_CONFIG_TOBLE_CENTRAL_ENABLE 0
+#define OPENTHREAD_CONFIG_TOBLE_PERIPHERAL_ENABLE 1
+#define OPENTHREAD_CONFIG_TOBLE_MULTI_RADIO_ENABLE 1
+#define OPENTHREAD_CONFIG_TOBLE_154_ATTACH_ATTEMPT_RATIO 2
+
+#define OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT 60
+
+#define OPENTHREAD_CONFIG_BLE_EVENTS 1
+#define OPENTHREAD_CONFIG_BLE_EVENT_QUEUE_SIZE 6
+
+#define OPENTHREAD_CONFIG_NORDIC_BLE_CFG_TAG NRF_BLE_CFG_TAG
+
+#define NRF_USE_SOFTDEVICE_TEMPERATURE 1
+
+#endif // OPENTHREAD_CONFIG_ENABLE_TOBLE
+
+// ==============================================================
+
 // Use the Nordic-supplied default platform configuration for remainder
-// of OpenThread config options.
+// of OpenThread config options. Include *after* application overrides above.
 //
 // NB: This file gets included during the build of OpenThread.  Hence
 // it cannot use "openthread" in the path to the included file.

--- a/main/include/WeaveProjectConfig.h
+++ b/main/include/WeaveProjectConfig.h
@@ -28,6 +28,8 @@
 #ifndef WEAVE_PROJECT_CONFIG_H
 #define WEAVE_PROJECT_CONFIG_H
 
+#include "ble_config.h"
+
 #if BUILD_RELEASE  // release build
 
 // Security and Authentication enabled for release build.
@@ -158,5 +160,30 @@
 #else
 #define WEAVE_CONFIG_EVENT_LOGGING_DEFAULT_IMPORTANCE nl::Weave::Profiles::DataManagement::Debug
 #endif // BUILD_RELEASE
+
+
+#if OPENTHREAD_CONFIG_ENABLE_TOBLE
+
+/**
+ * Ensures that WoBLE and ToBLE advertisements are not sent at the same time.
+ * When TOBLE is enabled, must be set to 1.
+ */
+#define WEAVE_DEVICE_CONFIG_WOBLE_SINGLE_CONNECTION 1
+
+/**
+ * Ensures that WoBLE and ToBLE advertisements are not sent at the same time.
+ * When TOBLE is enabled, must be set to 1.
+ */
+#define WEAVE_DEVICE_CONFIG_WOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED 1
+
+#endif
+
+/**
+ * WEAVE_DEVICE_LAYER_BLE_CONN_CFG_TAG
+ *
+ * The SoftDevice BLE connection configuration tag must be the same
+ * across both OpenWeave and OpenThread.
+ */
+#define WEAVE_DEVICE_LAYER_BLE_CONN_CFG_TAG NRF_BLE_CFG_TAG
 
 #endif // WEAVE_PROJECT_CONFIG_H

--- a/main/include/app_config.h
+++ b/main/include/app_config.h
@@ -19,6 +19,8 @@
 #ifndef APP_CONFIG_H
 #define APP_CONFIG_H
 
+#include "ble_config.h"
+
 // ----- Memory Config -----
 
 #define MEM_MANAGER_ENABLED 1
@@ -39,11 +41,11 @@
 #define NRF_SDH_ENABLED 1
 #define NRF_SDH_SOC_ENABLED 1
 #define NRF_SDH_BLE_ENABLED 1
-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 1
 #define NRF_SDH_BLE_VS_UUID_COUNT 2
 #define NRF_BLE_GATT_ENABLED 1
 #define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 251
 #define NRF_SDH_BLE_GAP_DATA_LENGTH 251
+#define NRF_SDH_DISPATCH_MODEL NRF_SDH_DISPATCH_MODEL_INTERRUPT
 
 // ----- FDS / Flash Config -----
 

--- a/main/include/ble_config.h
+++ b/main/include/ble_config.h
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef BLE_CONFIG_H
+#define BLE_CONFIG_H
+
+/**
+ * @file
+ *   This file implements the BLE configuration shared by OpenThread and OpenWeave.
+ */
+
+// ---- BLE Config ----
+#define NRF_BLE_CFG_TAG	1
+
+/**
+ * Increase # of connections supported to two so both WoBLE and ToBLE can advertise.
+ */
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT  2
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT     0
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT       NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+
+/**
+ * To enable the Thread-over-BLE feature set this to 1.
+ */
+#define OPENTHREAD_CONFIG_ENABLE_TOBLE 1
+
+#if OPENTHREAD_CONFIG_ENABLE_TOBLE
+/**
+ * When ToBLE enabled, use the same advertising handle for ToBLE and WoBLE.
+ */
+#define BLE_DEFAULT_ADVERTISING_HANDLE  0
+#else
+#define BLE_DEFAULT_ADVERTISING_HANDLE  BLE_GAP_ADV_SET_HANDLE_NOT_SET
+#endif
+
+#endif // BLE_CONFIG_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -56,6 +56,8 @@ extern "C" {
 #include <openthread/platform/platform-softdevice.h>
 }
 
+#include "OpenThreadConfig.h"
+
 #include <Weave/DeviceLayer/WeaveDeviceLayer.h>
 #include <Weave/DeviceLayer/ThreadStackManager.h>
 #include <Weave/DeviceLayer/nRF5/GroupKeyStoreImpl.h>
@@ -218,15 +220,29 @@ int main(void)
 
     {
         uint32_t appRAMStart = 0;
+        ble_cfg_t bleCfg;
 
         // Configure the BLE stack using the default settings.
         // Fetch the start address of the application RAM.
         ret = nrf_sdh_ble_default_cfg_set(WEAVE_DEVICE_LAYER_BLE_CONN_CFG_TAG, &appRAMStart);
         APP_ERROR_CHECK(ret);
 
+        // Increase the GATT table size to allow room for both WoBLE and ToBLE services.
+        memset(&bleCfg, 0, sizeof(bleCfg));
+        bleCfg.gatts_cfg.attr_tab_size.attr_tab_size = NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE * 2;
+        ret = sd_ble_cfg_set(BLE_GATTS_CFG_ATTR_TAB_SIZE, &bleCfg, appRAMStart);
+        APP_ERROR_CHECK(ret);
+
         // Enable BLE stack.
         ret = nrf_sdh_ble_enable(&appRAMStart);
         APP_ERROR_CHECK(ret);
+
+        ble_gap_addr_t bdaddr;
+        ret = sd_ble_gap_addr_get(&bdaddr);
+        APP_ERROR_CHECK(ret);
+        NRF_LOG_INFO("BDADDR: %02x:%02x:%02x:%02x:%02x:%02x",
+        bdaddr.addr[5], bdaddr.addr[4], bdaddr.addr[3],
+        bdaddr.addr[2], bdaddr.addr[1], bdaddr.addr[0]);
     }
 
 #endif // defined(SOFTDEVICE_PRESENT) && SOFTDEVICE_PRESENT


### PR DESCRIPTION
  - Add OpenThread configuration for ToBLE feature.
  - Make WoBLE and ToBLE use same BLE config tag on Nordic platforms.
  - Increase GATT table size to account for both services.
  - Add OpenThread logging configuration for platform and debug.
  - Pivot to event-based evaluation of provisioning state.
  - Recast ToBLE config to use feature/woble-coordinated-advertising
    framework in openweave-core.
  - Support dual-connection WoBLE / ToBLE.
  - Remove deprecated defines.
  - Make NRF advertising handle configurable.